### PR TITLE
DEV-766 [FIX] Ensures Data Record child elements remain visible in the screen structure when placed outside the Data Container.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -106,15 +106,19 @@
       });
 
 
-      if (!this.parent) {
+      if (!this.parent && !isInteract) {
         Fliplet.UI.Toast('Please add this component inside a Data container');
-
         return Promise.reject('Single record container must be placed inside a Data container');
       }
 
-      this.parent = await Fliplet.DynamicContainer.get(this.parent.id);
+      if (this.parent) {
+        this.parent = await Fliplet.DynamicContainer.get(this.parent.id);
+      } else {
+        // No parent but we're in Interact: proceed with placeholder data
+        this.parent = null;
+      }
 
-      if (!this.parent || !this.parent.connection) {
+      if ((!this.parent || !this.parent.connection) && !isInteract) {
         Fliplet.UI.Toast('Please configure the Data container with a data source');
 
         return Promise.reject('Data container is not properly configured');


### PR DESCRIPTION
### Product areas affected
Fliplet Widget Record Container

### What does this PR do?
Ensures Data REcord child elements remain visible in the screen structure when placed outside the Data Container.

### JIRA ticket
[DEV-766](https://weboo.atlassian.net/browse/DEV-766)

[DEV-766]: https://weboo.atlassian.net/browse/DEV-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interact mode now initialises without requiring a parent container or configured data source connection, enabling seamless use of placeholder data.
  * Standard mode validation requirements and behaviour remain completely unchanged, ensuring existing workflows function as expected.
  * Error handling paths preserved with mode-aware validation checks integrated throughout the initialisation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->